### PR TITLE
add 1 to size for null terminator of H5Aget_name

### DIFF
--- a/lib/raw/h5a_stubs.c
+++ b/lib/raw/h5a_stubs.c
@@ -415,10 +415,10 @@ value hdf5_h5a_get_name(value attr_v)
   size = H5Aget_name(attr_id, 0, NULL);
   if (size < 0)
     fail();
-  buf = malloc(size);
+  buf = malloc(size + 1);
   if (buf == NULL)
     caml_raise_out_of_memory();
-  size = H5Aget_name(attr_id, size, buf);
+  size = H5Aget_name(attr_id, size+1, buf);
   if (size < 0)
   {
     free(buf);


### PR DESCRIPTION
Taken from hdf5 [manual](https://support.hdfgroup.org/HDF5/doc1.6/RM_H5A.html#Annot-GetName):

> H5Aget_name retrieves the name of an attribute specified by the identifier, attr_id. Up to buf_size characters are stored in buf followed by a \0 string terminator. If the name of the attribute is longer than (buf_size -1), the string terminator is stored in the last position of the buffer to properly terminate the string.
