### PR TITLE
remove incorrect usage of noalloc

### DIFF
--- a/lib/raw/h5_raw.cppo.ml
+++ b/lib/raw/h5_raw.cppo.ml
@@ -33,11 +33,8 @@ module Ih_info = struct
     heap_size  : int }
 end
 
-#if OCAML_VERSION >= (4, 2, 0)
-external init : unit -> unit = "hdf5_h5_init" [@@noalloc]
-#else
-external init : unit -> unit = "hdf5_h5_init" "noalloc"
-#endif
+external init : unit -> unit = "hdf5_h5_init"
+
 let init () =
   Callback.register_exception "HDF5.H5I.Fail" H5i.Fail;
   init ()


### PR DESCRIPTION

My program segfaulted upon initialization and based on this [blog](https://blog.janestreet.com/faster-ocaml-to-c-calls/), I'm fairly certain it's because the hdf5 init method is declared as `noalloc` but in fact does allocations [here](https://github.com/vbrankov/hdf5-ocaml/blob/master/lib/raw/h5_stubs.c#L253). My program uses async and I think that complexity triggered the bug.

Eliminating the call to init or removing `noalloc` was sufficient to fix the issue. This PR just removes `noalloc` keywords.


