### PR TITLE
Add support for 4.08

### DIFF
--- a/lib/raw/h5a_stubs.c
+++ b/lib/raw/h5a_stubs.c
@@ -22,7 +22,10 @@ static struct custom_operations h5a_ops = {
   custom_compare_ext_default,
   custom_hash_default,
   custom_serialize_default,
-  custom_deserialize_default
+  custom_deserialize_default,
+#ifdef custom_fixed_length_default
+  custom_fixed_length_default,
+#endif
 };
 
 static value alloc_h5a(hid_t id)

--- a/lib/raw/h5d_stubs.c
+++ b/lib/raw/h5d_stubs.c
@@ -21,7 +21,10 @@ static struct custom_operations h5d_ops = {
   custom_compare_ext_default,
   custom_hash_default,
   custom_serialize_default,
-  custom_deserialize_default
+  custom_deserialize_default,
+#ifdef custom_fixed_length_default
+  custom_fixed_length_default,
+#endif
 };
 
 static value alloc_h5d(hid_t id)

--- a/lib/raw/h5f_stubs.c
+++ b/lib/raw/h5f_stubs.c
@@ -23,7 +23,10 @@ static struct custom_operations h5f_ops = {
   custom_compare_ext_default,
   custom_hash_default,
   custom_serialize_default,
-  custom_deserialize_default
+  custom_deserialize_default,
+#ifdef custom_fixed_length_default
+  custom_fixed_length_default,
+#endif
 };
 
 static value alloc_h5f(hid_t id)

--- a/lib/raw/h5g_stubs.c
+++ b/lib/raw/h5g_stubs.c
@@ -22,7 +22,10 @@ static struct custom_operations h5g_ops = {
   custom_compare_ext_default,
   custom_hash_default,
   custom_serialize_default,
-  custom_deserialize_default
+  custom_deserialize_default,
+#ifdef custom_fixed_length_default
+  custom_fixed_length_default,
+#endif
 };
 
 static value alloc_h5g(hid_t id, bool close)

--- a/lib/raw/h5l_stubs.c
+++ b/lib/raw/h5l_stubs.c
@@ -54,7 +54,10 @@ static struct custom_operations h5l_ops = {
   custom_compare_ext_default,
   custom_hash_default,
   custom_serialize_default,
-  custom_deserialize_default
+  custom_deserialize_default,
+#ifdef custom_fixed_length_default
+  custom_fixed_length_default,
+#endif
 };
 
 static value alloc_h5l(hid_t id)

--- a/lib/raw/h5o_stubs.c
+++ b/lib/raw/h5o_stubs.c
@@ -19,7 +19,10 @@ static struct custom_operations h5o_ops = {
   custom_compare_ext_default,
   custom_hash_default,
   custom_serialize_default,
-  custom_deserialize_default
+  custom_deserialize_default,
+#ifdef custom_fixed_length_default
+  custom_fixed_length_default,
+#endif
 };
 
 static value alloc_h5o(hid_t id, bool close)

--- a/lib/raw/h5p_stubs.c
+++ b/lib/raw/h5p_stubs.c
@@ -44,7 +44,10 @@ static struct custom_operations h5p_ops = {
   custom_compare_ext_default,
   custom_hash_default,
   custom_serialize_default,
-  custom_deserialize_default
+  custom_deserialize_default,
+#ifdef custom_fixed_length_default
+  custom_fixed_length_default,
+#endif
 };
 
 value alloc_h5p(hid_t id)

--- a/lib/raw/h5r_stubs.c
+++ b/lib/raw/h5r_stubs.c
@@ -11,7 +11,10 @@ static struct custom_operations h5r_ops = {
   custom_compare_ext_default,
   custom_hash_default,
   custom_serialize_default,
-  custom_deserialize_default
+  custom_deserialize_default,
+#ifdef custom_fixed_length_default
+  custom_fixed_length_default,
+#endif
 };
 
 value alloc_h5r(hid_t id)

--- a/lib/raw/h5s_stubs.c
+++ b/lib/raw/h5s_stubs.c
@@ -19,7 +19,10 @@ static struct custom_operations h5s_ops = {
   custom_compare_ext_default,
   custom_hash_default,
   custom_serialize_default,
-  custom_deserialize_default
+  custom_deserialize_default,
+#ifdef custom_fixed_length_default
+  custom_fixed_length_default,
+#endif
 };
 
 value alloc_h5s(hid_t id)

--- a/lib/raw/h5t_stubs.c
+++ b/lib/raw/h5t_stubs.c
@@ -19,7 +19,10 @@ static struct custom_operations h5t_ops = {
   custom_compare_ext_default,
   custom_hash_default,
   custom_serialize_default,
-  custom_deserialize_default
+  custom_deserialize_default,
+#ifdef custom_fixed_length_default
+  custom_fixed_length_default,
+#endif
 };
 
 value alloc_h5t(hid_t id)

--- a/lib/raw/hid_stubs.c
+++ b/lib/raw/hid_stubs.c
@@ -10,7 +10,10 @@ static struct custom_operations hid_ops = {
   custom_compare_ext_default,
   custom_hash_default,
   custom_serialize_default,
-  custom_deserialize_default
+  custom_deserialize_default,
+#ifdef custom_fixed_length_default
+  custom_fixed_length_default,
+#endif
 };
 
 value alloc_hid(hid_t id)


### PR DESCRIPTION
The upcoming OCaml 4.08 introduces a new field in
custom blocks, namely custom_fixed_length_default.

This pull request uses conditional compilation to
support both 4.07 and 4.08.