### PR TITLE
Construct H5.t from Hid.t

### DIFF
--- a/src/caml/h5.cppo.ml
+++ b/src/caml/h5.cppo.ml
@@ -69,6 +69,12 @@ let hid = function
 | File f -> f
 | Group g -> g
 
+let dataset d = Dataset d
+
+let file f = File f
+
+let group g = Group g
+
 type open_ = ?meta_block_size:int -> ?split:bool -> string -> t
 
 let open_ (open_ : string -> ?fapl : Hid.t -> H5f.Acc.t list -> Hid.t) acc =

--- a/src/caml/h5.cppo.ml
+++ b/src/caml/h5.cppo.ml
@@ -69,11 +69,29 @@ let hid = function
 | File f -> f
 | Group g -> g
 
-let dataset d = Dataset d
+let dataset d =
+  match H5i.get_type d with
+  | H5i.Type.DATASET -> File d
+  | _ -> raise H5i.Fail
 
-let file f = File f
+let file f =
+  match H5i.get_type f with
+  | H5i.Type.FILE -> File f
+  | _ -> raise H5i.Fail
 
-let group g = Group g
+let group g =
+  match H5i.get_type g with
+  | H5i.Type.GROUP -> Group g
+  | _ -> raise H5i.Fail
+
+let h5t x =
+  let open H5i in
+  let open Type in
+  match get_type x with
+  | FILE -> File x
+  | GROUP-> Group x
+  | DATASET-> Dataset x
+  | _ -> raise Fail
 
 type open_ = ?meta_block_size:int -> ?split:bool -> string -> t
 

--- a/src/caml/h5.mli
+++ b/src/caml/h5.mli
@@ -90,6 +90,15 @@ val create_external_link : t -> target_file_name:string -> target_obj_name:strin
 (** Returns the HDF5 handle *)
 val hid : t -> Hid.t
 
+(** Construct Dataset H5.t from HDF5 handle *)
+val dataset : Hid.t -> t
+
+(** Construct File H5.t from HDF5 handle *)
+val file : Hid.t -> t
+
+(** Construct Group H5.t from HDF5 handle *)
+val group : Hid.t -> t
+
 (** Writes the given uint8 Array1.t to the data set. *)
 val write_uint8_array1 : t -> string -> ?deflate:int
   -> (char, int8_unsigned_elt, _) Array1.t -> unit

--- a/src/caml/h5.mli
+++ b/src/caml/h5.mli
@@ -90,14 +90,17 @@ val create_external_link : t -> target_file_name:string -> target_obj_name:strin
 (** Returns the HDF5 handle *)
 val hid : t -> Hid.t
 
-(** Construct Dataset H5.t from HDF5 handle *)
+(** Construct H5.t from dataset HDF5 handle *)
 val dataset : Hid.t -> t
 
-(** Construct File H5.t from HDF5 handle *)
+(** Construct H5.t from file HDF5 handle *)
 val file : Hid.t -> t
 
-(** Construct Group H5.t from HDF5 handle *)
+(** Construct H5.t from group HDF5 handle *)
 val group : Hid.t -> t
+
+(** Construct H5.t from group, file, or dataset HDF5 handle *)
+val h5t : Hid.t -> t
 
 (** Writes the given uint8 Array1.t to the data set. *)
 val write_uint8_array1 : t -> string -> ?deflate:int


### PR DESCRIPTION
I've added several functions that constructs `H5.t` from `Hid.t` (e.g. `val dataset : Hid.t -> H5.t`). Conceptually this is inverse of `H5.hid`. 
These functions are useful when using functions in `Hdf5_caml` and `Hdf5_raw` together. One such example is applying `H5.read_float` when iterating through the links in a group with `H5l.iterate_by_name`.

The function `h5t` checks whether the input of type `Hid.t` is a group, file, or dataset and returns the right `H5.t` variant.