### PR TITLE
add discovered c_flags

### DIFF
--- a/src/caml/dune
+++ b/src/caml/dune
@@ -2,7 +2,7 @@
  (name hdf5_caml)
  (public_name hdf5.caml)
  (c_names struct_stubs)
- (c_flags (:standard -Wall -pedantic -Wextra -Wunused -Werror -Wno-long-long))
+ (c_flags (:standard -Wall -pedantic -Wextra -Wunused -Werror -Wno-long-long (:include c_flags.sexp)))
  (libraries bigarray hdf5_raw)
  (inline_tests)
  (preprocess (pps ppx_inline_test)))
@@ -16,3 +16,10 @@
  (targets struct.ml)
  (deps    (:first-dep struct.cppo.ml))
  (action  (run %{bin:cppo} -V OCAML:%{ocaml_version} %{first-dep} -o %{targets})))
+
+(rule
+ (targets c_flags.sexp c_library_flags.sexp)
+ (deps
+  (:discover ../raw/config/discover.exe))
+ (action
+  (run %{discover})))


### PR DESCRIPTION
I think, there are `c_flags` missing to build `hdf5.caml`:
[struct_stubs.c](https://github.com/vbrankov/hdf5-ocaml/blob/master/src/caml/struct_stubs.c) is referencing [hdf5_caml.h](https://github.com/vbrankov/hdf5-ocaml/blob/master/src/raw/hdf5_caml.h), which looks for `hdf5.h`.
I am not sure this fix is the most elegant solution, as now `hdf5.caml` refers to the [config/discover](https://github.com/vbrankov/hdf5-ocaml/tree/master/src/raw/config), which belongs to `hdf5.raw`. Maybe you want to move `src/raw/config/` one level up (`src/config/`).