### PR TITLE
fix link to HDF5 doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ let () =
 # lib/raw - raw HDF5 wrapper
 
 Equivalent to the HDF5 C library function-for-function.
-[HDF5 C documentation](https://www.hdfgroup.org/HDF5/doc/RM/RM_H5Front.html) can be used.
+[HDF5 C documentation](https://portal.hdfgroup.org/display/HDF5/HDF5) can be used.
 
 ```ocaml
 open Bigarray


### PR DESCRIPTION
The location of the HDF5 documentation has changed.