### PR TITLE
switch to ppxlib

### DIFF
--- a/hdf5.opam
+++ b/hdf5.opam
@@ -13,7 +13,7 @@ depends: [
   "dune" {build & >= "1.1.0"}
   "ocaml" {>= "4.04"}
   "ppx_inline_test"
-  "ppx_tools_versioned"
+  "ppxlib"
   "stdio"
 ]
 depexts: [

--- a/src/ppx/dune
+++ b/src/ppx/dune
@@ -7,4 +7,4 @@
  (name ppx_h5struct)
  (public_name hdf5.ppx)
  (kind ppx_rewriter) 
- (libraries ppx_tools_versioned))
+ (libraries ppxlib))


### PR DESCRIPTION
This is a proposal for basing the ppx extension on `ppxlib`, as `ppx_tools_versioned` [is going to be deprecated](https://discuss.ocaml.org/t/ocaml-migrate-parsetree-2-0-0/5991). This new version passes all tests performed by a dune runtest invocation.