### PR TITLE
fixed gcc flags for caml sublibrary

### DIFF
--- a/src/caml/dune
+++ b/src/caml/dune
@@ -2,7 +2,7 @@
  (name hdf5_caml)
  (public_name hdf5.caml)
  (c_names struct_stubs)
- (c_flags (:standard -Wall -pedantic -Wextra -Wunused -Werror -Wno-long-long))
+ (c_flags ((:standard -Wall -pedantic -Wextra -Wunused -Werror -Wno-long-long) (:include ../raw/c_flags.sexp)))
  (libraries bigarray hdf5_raw)
  (inline_tests)
  (preprocess (pps ppx_inline_test)))


### PR DESCRIPTION
I had the following compilation error:
```
$dune build
         gcc src/caml/struct_stubs.o (exit 1)
(cd _build/default/src/caml && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -fPIC -D_FILE_OFFSET_BITS=64 -D_REENTRANT -O2 -fno-strict-aliasing -fwrapv -fPIC -Wall -pedantic -Wextra -Wunused -Werror -Wno-long-long -g -I /home/pveber/.opam/4.11.1/lib/ocaml -I /home/pveber/.opam/4.11.1/lib/base -I /home/pveber/.opam/4.11.1/lib/base/base_internalhash_types -I /home/pveber/.opam/4.11.1/lib/base/caml -I /home/pveber/.opam/4.11.1/lib/base/shadow_stdlib -I /home/pveber/.opam/4.11.1/lib/jane-street-headers -I /home/pveber/.opam/4.11.1/lib/ppx_compare/runtime-lib -I /home/pveber/.opam/4.11.1/lib/ppx_enumerate/runtime-lib -I /home/pveber/.opam/4.11.1/lib/ppx_hash/runtime-lib -I /home/pveber/.opam/4.11.1/lib/ppx_inline_test/config -I /home/pveber/.opam/4.11.1/lib/ppx_inline_test/runtime-lib -I /home/pveber/.opam/4.11.1/lib/ppx_sexp_conv/runtime-lib -I /home/pveber/.opam/4.11.1/lib/sexplib0 -I /home/pveber/.opam/4.11.1/lib/time_now -I ../raw -o struct_stubs.o -c struct_stubs.c)
In file included from struct_stubs.c:11:
../raw/hdf5_caml.h:2:10: fatal error: hdf5.h: Aucun fichier ou dossier de ce type
    2 | #include "hdf5.h"
      |          ^~~~~~~~
```
This patch adds the `-I` gcc flag that is generated in the `raw` directory.