### PR TITLE
don't use free as extern

### DIFF
--- a/src/raw/c_string.ml
+++ b/src/raw/c_string.ml
@@ -8,4 +8,4 @@ external of_string : string -> t = "hdf5_c_string_of_string"
 external to_string : t -> string = "hdf5_c_string_to_string"
 external to_bigstring : t -> (char, int8_unsigned_elt, c_layout) Array1.t
   = "hdf5_c_string_to_bigstring"
-external free : t -> unit = "free"
+external free : t -> unit = "hdf5_c_string_free"

--- a/src/raw/c_string.mli
+++ b/src/raw/c_string.mli
@@ -7,4 +7,4 @@ external of_string : string -> t = "hdf5_c_string_of_string"
 external to_string : t -> string = "hdf5_c_string_to_string"
 external to_bigstring : t -> (char, int8_unsigned_elt, c_layout) Array1.t
   = "hdf5_c_string_to_bigstring"
-external free : t -> unit = "free"
+external free : t -> unit = "hdf5_c_string_free"

--- a/src/raw/c_string_stubs.c
+++ b/src/raw/c_string_stubs.c
@@ -5,6 +5,11 @@
 #include <caml/memory.h>
 #include "hdf5_caml.h"
 
+value hdf5_c_string_free(value s_v) {
+  free((char*) s_v);
+  return(Val_unit);
+}
+
 value hdf5_c_string_of_string(value s_v)
 {
   CAMLparam1(s_v);


### PR DESCRIPTION
declaring free as a C foreign function in C_string:
```ocaml
external free : t -> unit = "free"
```

leads to linking issues when compiling a custom (utop)level (although
it causes no issue when compiling to an executable, no idea why):

```
$ dune utop src
[...]
/tmp/camlobjb4c20d.c:337131:14: error: conflicting types for ‘free’
324045 | extern value free();
       |              ^~~~
In file included from /home/pveber/.opam/4.11.1/lib/ocaml/caml/misc.h:29,
                 from /home/pveber/.opam/4.11.1/lib/ocaml/caml/mlvalues.h:23,
                 from /tmp/camlobje4d0c5.c:6:
/usr/include/stdlib.h:565:13: note: previous declaration of ‘free’ was here
  565 | extern void free (void *__ptr) __THROW;
[...]
```

This commit introduces a proper wrapper around free, called `hdf5_c_string_free`