### PR TITLE
Remove reference to H5I_REFERENCE

### DIFF
--- a/src/raw/h5i_stubs.c
+++ b/src/raw/h5i_stubs.c
@@ -24,7 +24,6 @@ H5I_type_t H5I_type_val(value v)
     case  3: return H5I_DATASPACE;
     case  4: return H5I_DATASET;
     case  5: return H5I_ATTR;
-    case  6: return H5I_REFERENCE;
     case  7: return H5I_VFL;
     case  8: return H5I_GENPROP_CLS;
     case  9: return H5I_GENPROP_LST;
@@ -48,7 +47,6 @@ value Val_h5i_type(H5I_type_t v)
     case H5I_DATASPACE   : return Val_int( 3);
     case H5I_DATASET     : return Val_int( 4);
     case H5I_ATTR        : return Val_int( 5);
-    case H5I_REFERENCE   : return Val_int( 6);
     case H5I_VFL         : return Val_int( 7);
     case H5I_GENPROP_CLS : return Val_int( 8);
     case H5I_GENPROP_LST : return Val_int( 9);


### PR DESCRIPTION
Deprecated in 1.10, removed some time later
(https://support.hdfgroup.org/ftp/HDF5/prev-releases/ReleaseFiles/hdf5-1.10.2-RELEASE.txt).

This currently results in a build error:

```
File "src/raw/dune", line 10, characters 2-11:
10 |   h5i_stubs
       ^^^^^^^^^
h5i_stubs.c: In function ‘H5I_type_val’:
h5i_stubs.c:27:21: error: ‘H5I_REFERENCE’ undeclared (first use in this function); did you mean ‘H5T_REFERENCE’?
   27 |     case  6: return H5I_REFERENCE;
      |                     ^~~~~~~~~~~~~
      |                     H5T_REFERENCE
h5i_stubs.c:27:21: note: each undeclared identifier is reported only once for each function it appears in
h5i_stubs.c: In function ‘Val_h5i_type’:
h5i_stubs.c:51:10: error: ‘H5I_REFERENCE’ undeclared (first use in this function); did you mean ‘H5T_REFERENCE’?
   51 |     case H5I_REFERENCE   : return Val_int( 6);
      |          ^~~~~~~~~~~~~
      |          H5T_REFERENCE
```

which vanishes upon application of this patch.